### PR TITLE
boards: stm32h573i_dk: add touch panel support

### DIFF
--- a/boards/st/stm32h573i_dk/Kconfig.defconfig
+++ b/boards/st/stm32h573i_dk/Kconfig.defconfig
@@ -33,4 +33,14 @@ config REGULATOR
 
 endif # DISPLAY
 
+config INPUT
+	default y if LVGL
+
+if INPUT
+
+config INPUT_FT5336_INTERRUPT
+	default y
+
+endif # INPUT
+
 endif # BOARD_STM32H573I_DK

--- a/boards/st/stm32h573i_dk/doc/index.rst
+++ b/boards/st/stm32h573i_dk/doc/index.rst
@@ -180,14 +180,14 @@ Serial Port
 STM32H573I-DK Discovery board has 3 U(S)ARTs. The Zephyr console output is
 assigned to USART1. Default settings are 115200 8N1.
 
-TFT LCD screen
---------------
+TFT LCD screen and touch panel
+------------------------------
 
-The TFT LCD screen is supported for the STM32H573I-DK Discovery board.
-It can be tested using :zephyr:code-sample:`display` sample:
+The TFT LCD screen and touch panel are supported for the STM32H573I-DK Discovery board.
+They can be tested using :zephyr:code-sample:`lvgl` sample:
 
 .. zephyr-app-commands::
-   :zephyr-app: samples/drivers/display
+   :zephyr-app: samples/subsys/display/lvgl
    :board: stm32h573i_dk
    :goals: build
 

--- a/boards/st/stm32h573i_dk/stm32h573i_dk.dts
+++ b/boards/st/stm32h573i_dk/stm32h573i_dk.dts
@@ -80,6 +80,12 @@
 		/* The ATTR_MPU_EXTMEM attribut causing a MPU FAULT */
 		zephyr,memory-attr = <( DT_MEM_ARM(ATTR_MPU_IO) )>;
 	};
+
+	lvgl_pointer {
+		compatible = "zephyr,lvgl-pointer-input";
+		input = <&ft5336>;
+		invert-y;
+	};
 };
 
 &fmc {
@@ -198,6 +204,22 @@
 	pinctrl-names = "default";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	status = "okay";
+};
+
+&i2c4 {
+	pinctrl-0 = <&i2c4_scl_pb8 &i2c4_sda_pb9>;
+	pinctrl-names = "default";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	status = "okay";
+
+	/* The board embeds the Self-Capacitive Touch Panel Controller ft3267
+	that can be controlled by the ft5336 driver */
+	ft5336: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		int-gpios = <&gpiog 7 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpiog 3 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &usart1 {


### PR DESCRIPTION
The stm32h573i_dk board uses a ft3267 i2c controller for the touchscreen. The zephyr driver ft5336 can control it.

Signed-off-by: Samuel Quiniou samuel.quiniou@rtone.fr

## Summary

- Add touch panel support for the ft3267 Self-Capacitive Touch Panel Controller, connected on I2C4.
- Use the zephyr driver ft5336 to control it.
  - :information_source: The PR https://github.com/zephyrproject-rtos/zephyr/pull/78971 uses the zephyr driver ft5336 to control the ft6x06 with the I2C Slave Address 0x70.
  - :information_source: The [BSP of the board from ST](https://github.com/STMicroelectronics/stm32h573i-discovery-bsp/blob/main/stm32h573i_discovery_ts.c#L704) uses the ft6x06 with the I2C Slave Address 0x70
  - :information_source: 8bits I2C Slave Address 0x70 = 7bits I2C Slave Address 0x38
- Update the documentation of the board.

## Tests

### Environment

Tested on an stm32h573i-dk board (mb1677-h573i-c02) with the `lvgl` sample.

### Commands

```sh
$ west build -p always -b stm32h573i_dk zephyr/samples/subsys/display/lvgl
$ west flash --runner pyocd
```

### Results

- The `Hello world!` label appears.
- Pressing the `Hello world!` label resets the counter.

![IMG20250504233652](https://github.com/user-attachments/assets/f963c3e5-3f8e-487b-be87-63faea3fdf65)

## References

- Schematics of the stm32h573i-dk board used for the pinout: https://www.st.com/resource/en/schematic_pack/mb1677-h573i-c02-schematic.pdf
- PR of the support of the touch panel for the STM32L562E-DK: https://github.com/zephyrproject-rtos/zephyr/pull/78971